### PR TITLE
LPD-86832 Fix Smoke.runSmoke Poshi flow for new global menu

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/applicationsmenunavigation/ApplicationsMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/applicationsmenunavigation/ApplicationsMenu.macro
@@ -37,6 +37,12 @@ definition {
 				key_panel = ${panel},
 				locator1 = "ApplicationsMenu#PANEL_TITLE");
 		}
+
+		if (IsElementPresent(locator1 = "ProductMenu#PRODUCT_MENU_CLOSED")) {
+			Click(locator1 = "ProductMenu#TOGGLE");
+
+			WaitForElementPresent(locator1 = "ProductMenu#PRODUCT_MENU_OPENED");
+		}
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -83,8 +83,14 @@ definition {
 
 	@summary = "Default summary"
 	macro gotoPortlet(site = null, portlet = null, category = null) {
-		if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
+		if (isSet(site)) {
 			ApplicationsMenu.gotoSite(site = ${site});
+
+			var siteNameURL = StringUtil.replace(${site}, " ", "-");
+
+			var siteNameURL = StringUtil.lowerCase(${siteNameURL});
+
+			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
 		}
 
 		ProductMenuHelper.openProductMenu();

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>VIEW_ALL_LINK</td>
-	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//button[@role='menuitem' and contains(.,'View All')]</td>
+	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//*[@role='menuitem' and contains(.,'View All')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
@@ -32,22 +32,22 @@
 </tr>
 <tr>
 	<td>TOGGLE</td>
-	<td>//*[@data-qa-id='productMenu']</td>
+	<td>//button[@data-qa-id='sideNavigationToggler']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PRODUCT_MENU_BODY</td>
-	<td>//*[@data-qa-id='productMenuBody'] | //*[@data-qa-id='sideNavigation']</td>
+	<td>//*[@data-qa-id='sideNavigation']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PRODUCT_MENU_OPENED</td>
-	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'open') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'closed'))]</td>
+	<td>//*[@data-qa-id='sideNavigation' and contains(@class,'c-slideout-show')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PRODUCT_MENU_CLOSED</td>
-	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'closed') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'open'))]</td>
+	<td>//*[@data-qa-id='sideNavigation' and not(contains(@class,'c-slideout-show'))]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

`Smoke.runSmoke` fails at `ProductMenu.gotoPortlet(category="Site Builder", portlet="Pages", site="Site Name")` because the new global menu (LPD-74387) replaced legacy markup the macros and Poshi locators relied on. This fixes the four affected files so the per-site Product Menu navigation reaches `data-qa-id='sideNavigation'` cleanly.

## Changes

- **ProductMenu.path** — retarget `TOGGLE`, `PRODUCT_MENU_OPENED`, `PRODUCT_MENU_CLOSED`, `PRODUCT_MENU_BODY` at the new SideNavigation / SideNavigationToggler markup (`data-qa-id='sideNavigationToggler'`, `data-qa-id='sideNavigation'`). OPENED/CLOSED anchored on the section's `c-slideout-show` class — the authoritative visibility marker (the toggler's `aria-expanded` doesn't sync reliably right after navigation).
- **ApplicationsMenu.path** — drop the `<button>` tag predicate from `VIEW_ALL_LINK` so it matches the new GlobalMenu's `<a>` "View All Sites" anchor (Clay `DropdownItem`).
- **ApplicationsMenu.macro:gotoPanel** — click the SideNavigationToggler when the drawer is closed, then wait for it to open. Side-nav DOM presence is no longer enough; the Control Panel home defaults closed and `expandCategory` / `Click(PORTLET)` would otherwise hit zero-size elements.
- **ProductMenu.macro:gotoPortlet** — always `gotoSite` when `site` is set, then navigate explicitly to `/group/<friendly>/~/control_panel/manage` so the per-site SideNavigation renders before `openProductMenu` runs. Drops the legacy "skip gotoSite if `ProductMenu#TOGGLE` is present" guard, which was stale: the new toggler lives in the control menu of every page, so the guard always evaluated true and skipped `gotoSite` even when it shouldn't have.

## Test plan

- [ ] Run the originally failing tests and confirm they pass:
  - `LocalFile.DBMigrationImport#CanImportDatabaseToPostgreSQL`
  - `LocalFile.DatabasePartitioning#ExportNonPartitionedCompanyAndAddDBPartition`
- [ ] Spot-check related tests that exercise the same macros (any test calling `ProductMenu.gotoPortlet` with `site=` or `ApplicationsMenu.gotoPortlet` with `panel="Control Panel"`) for regressions.
- [ ] Run a Smoke pass on a fresh bundle to confirm the macro chain reaches `AssertVisible(ProductMenu#PRODUCT_MENU_BODY)` without timing out.

## Notes

- Marked draft pending the local Poshi run that exercises only this surface (see `ProductMenuGotoPortletLocal#GotoPortletViaExistingSite`, kept as a local scaffold). A pre-existing regression in `Site.addBlankCP` (post-creation page expects a `list-group-card-item-text` for "Site Configuration" that no longer renders) blocks running `Smoke.runSmoke` end-to-end locally — that's outside this ticket and should be filed separately.