### PR TITLE
LPD-84027 Implement Background Thread for Locked Query Polling

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -49,6 +49,7 @@ import com.liferay.portal.transaction.TransactionsUtil;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.data.cleanup.DataCleanupPreupgradeProcessSuite;
 import com.liferay.portal.upgrade.log.UpgradeLogContext;
+import com.liferay.portal.upgrade.monitor.UpgradeQueryMonitor;
 import com.liferay.portal.util.InitUtil;
 import com.liferay.portal.util.PortalClassPathUtil;
 import com.liferay.portal.verify.PreupgradeVerifyProcessSuite;
@@ -249,9 +250,13 @@ public class DBUpgrader {
 		serviceLatch.openOn(
 			() -> {
 			});
+
+		UpgradeQueryMonitor.start();
 	}
 
 	public static void stopUpgradeLogAppender() {
+		UpgradeQueryMonitor.stop();
+
 		UpgradeLogProgressTracker.stop();
 
 		if ((_appender != null) && _appender.isStarted()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.monitor;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.NamedThreadFactory;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import java.sql.Connection;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Jorge Avalos
+ */
+public class UpgradeQueryMonitor {
+
+	public static synchronized void start() {
+		if (!PropsValues.UPGRADE_QUERY_MONITOR_ENABLED ||
+			(_scheduledExecutorService != null)) {
+
+			return;
+		}
+
+		_scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+			new NamedThreadFactory(
+				"Liferay Upgrade Query Monitor", Thread.NORM_PRIORITY, null));
+
+		_scheduledExecutorService.scheduleWithFixedDelay(
+			UpgradeQueryMonitor::_poll, _POLLING_INTERVAL_SECONDS,
+			_POLLING_INTERVAL_SECONDS, TimeUnit.SECONDS);
+	}
+
+	public static synchronized void stop() {
+		if (_scheduledExecutorService == null) {
+			return;
+		}
+
+		_scheduledExecutorService.shutdownNow();
+
+		try {
+			if (!_scheduledExecutorService.awaitTermination(
+					_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Upgrade query monitor did not terminate within ",
+							_SHUTDOWN_TIMEOUT_SECONDS, " seconds."));
+				}
+			}
+		}
+		catch (InterruptedException interruptedException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(interruptedException);
+			}
+
+			Thread.currentThread(
+			).interrupt();
+		}
+
+		_scheduledExecutorService = null;
+	}
+
+	private static void _poll() {
+		DataSource dataSource = InfrastructureUtil.getDataSource();
+
+		if (dataSource == null) {
+			return;
+		}
+
+		try (Connection connection = dataSource.getConnection()) {
+			DB db = DBManagerUtil.getDB();
+
+			List<DB.QueryInfo> lockedQueryInfos = db.getLockedQueryInfos(
+				connection);
+
+			for (DB.QueryInfo lockedQueryInfo : lockedQueryInfos) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Query \"", lockedQueryInfo.getQuery(), "\" (id ",
+							lockedQueryInfo.getId(),
+							"), which has been running for ",
+							TimeUnit.MILLISECONDS.toSeconds(
+								lockedQueryInfo.getDuration()),
+							" seconds, is locked."));
+				}
+			}
+		}
+		catch (Exception exception) {
+			if (Thread.currentThread(
+				).isInterrupted()) {
+
+				return;
+			}
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Upgrade query monitoring was disabled because locked " +
+						"query detection failed: " + exception.getMessage());
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			ReflectionUtil.throwException(exception);
+		}
+	}
+
+	private static final long _POLLING_INTERVAL_SECONDS = 60;
+
+	private static final long _SHUTDOWN_TIMEOUT_SECONDS = 5;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradeQueryMonitor.class);
+
+	private static ScheduledExecutorService _scheduledExecutorService;
+
+}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -227,6 +227,14 @@
     upgrade.log.progress.interval=300000
 
     #
+    # Set to true to enable the background thread that monitors long-running
+    # locked queries during upgrades.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_ENABLED
+    #
+    upgrade.query.monitor.enabled=true
+
+    #
     # Set the threshold in milliseconds before a query waiting on resources is
     # flagged as locked.
     #

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -1,0 +1,333 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.monitor;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.sql.DataSource;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class UpgradeQueryMonitorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@After
+	public void tearDown() {
+		UpgradeQueryMonitor.stop();
+	}
+
+	@Test
+	public void testPoll() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.WARN)) {
+
+			Connection connection = Mockito.mock(Connection.class);
+
+			DataSource dataSource = Mockito.mock(DataSource.class);
+
+			Mockito.when(
+				dataSource.getConnection()
+			).thenReturn(
+				connection
+			);
+
+			DB db = Mockito.mock(DB.class);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			String id1 = RandomTestUtil.randomString();
+			String id2 = RandomTestUtil.randomString();
+			String id3 = RandomTestUtil.randomString();
+			String id4 = RandomTestUtil.randomString();
+			String queryString1 = RandomTestUtil.randomString();
+			String queryString2 = RandomTestUtil.randomString();
+			String queryString3 = RandomTestUtil.randomString();
+			String queryString4 = RandomTestUtil.randomString();
+
+			String expectedMessage1 = StringBundler.concat(
+				"Query \"", queryString1, "\" (id ", id1,
+				"), which has been running for 30 seconds, is locked.");
+			String expectedMessage2 = StringBundler.concat(
+				"Query \"", queryString2, "\" (id ", id2,
+				"), which has been running for 300 seconds, is locked.");
+			String expectedMessage3 = StringBundler.concat(
+				"Query \"", queryString3, "\" (id ", id3,
+				"), which has been running for 600 seconds, is locked.");
+			String expectedMessage4 = StringBundler.concat(
+				"Query \"", queryString4, "\" (id ", id4,
+				"), which has been running for 900 seconds, is locked.");
+
+			DataSource originalDataSource = InfrastructureUtil.getDataSource();
+
+			InfrastructureUtil.setDataSource(dataSource);
+
+			try {
+				Mockito.when(
+					db.getLockedQueryInfos(connection)
+				).thenReturn(
+					Collections.emptyList()
+				);
+
+				ReflectionTestUtil.invoke(
+					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+				List<LogEntry> logEntries = logCapture.getLogEntries();
+
+				Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
+
+				Mockito.when(
+					db.getLockedQueryInfos(connection)
+				).thenReturn(
+					Collections.singletonList(
+						new DB.QueryInfo(
+							30000, id1, queryString1,
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()))
+				);
+
+				ReflectionTestUtil.invoke(
+					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+				logEntries = logCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 1, logEntries.size());
+				Assert.assertEquals(
+					expectedMessage1,
+					logEntries.get(
+						0
+					).getMessage());
+				Assert.assertEquals(
+					"WARN",
+					logEntries.get(
+						0
+					).getPriority());
+
+				Mockito.when(
+					db.getLockedQueryInfos(connection)
+				).thenReturn(
+					Arrays.asList(
+						new DB.QueryInfo(
+							300000, id2, queryString2,
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()),
+						new DB.QueryInfo(
+							600000, id3, queryString3,
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()),
+						new DB.QueryInfo(
+							900000, id4, queryString4,
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()))
+				);
+
+				ReflectionTestUtil.invoke(
+					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+				logEntries = logCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 4, logEntries.size());
+				Assert.assertEquals(
+					expectedMessage2,
+					logEntries.get(
+						1
+					).getMessage());
+				Assert.assertEquals(
+					expectedMessage3,
+					logEntries.get(
+						2
+					).getMessage());
+				Assert.assertEquals(
+					expectedMessage4,
+					logEntries.get(
+						3
+					).getMessage());
+			}
+			finally {
+				InfrastructureUtil.setDataSource(originalDataSource);
+			}
+		}
+	}
+
+	@Test
+	public void testPollDisablesMonitoringOnSQLException() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.WARN)) {
+
+			Connection connection = Mockito.mock(Connection.class);
+
+			DataSource dataSource = Mockito.mock(DataSource.class);
+
+			Mockito.when(
+				dataSource.getConnection()
+			).thenReturn(
+				connection
+			);
+
+			DB db = Mockito.mock(DB.class);
+
+			String exceptionMessage = RandomTestUtil.randomString();
+
+			Mockito.when(
+				db.getLockedQueryInfos(connection)
+			).thenThrow(
+				new SQLException(exceptionMessage)
+			);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			DataSource originalDataSource = InfrastructureUtil.getDataSource();
+
+			InfrastructureUtil.setDataSource(dataSource);
+
+			try {
+				Assert.assertThrows(
+					SQLException.class,
+					() -> ReflectionTestUtil.invoke(
+						UpgradeQueryMonitor.class, "_poll", new Class<?>[0]));
+
+				List<LogEntry> logEntries = logCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 1, logEntries.size());
+				Assert.assertEquals(
+					"Upgrade query monitoring was disabled because locked " +
+						"query detection failed: " + exceptionMessage,
+					logEntries.get(
+						0
+					).getMessage());
+			}
+			finally {
+				InfrastructureUtil.setDataSource(originalDataSource);
+			}
+		}
+	}
+
+	@Test
+	public void testStartIsNoOpWhenAlreadyStarted() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", true)) {
+
+			UpgradeQueryMonitor.start();
+
+			ScheduledExecutorService scheduledExecutorService =
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, "_scheduledExecutorService");
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertSame(
+				scheduledExecutorService,
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, "_scheduledExecutorService"));
+		}
+	}
+
+	@Test
+	public void testStartIsNoOpWhenDisabled() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", false)) {
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, "_scheduledExecutorService"));
+		}
+	}
+
+	@Test
+	public void testStartSchedulesExecutor() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", true)) {
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertNotNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, "_scheduledExecutorService"));
+		}
+	}
+
+	@Test
+	public void testStopIsIdempotentWhenNotStarted() {
+		UpgradeQueryMonitor.stop();
+
+		Assert.assertNull(
+			ReflectionTestUtil.getFieldValue(
+				UpgradeQueryMonitor.class, "_scheduledExecutorService"));
+	}
+
+	@Test
+	public void testStopShutsDownExecutor() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", true)) {
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertNotNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, "_scheduledExecutorService"));
+
+			UpgradeQueryMonitor.stop();
+
+			Assert.assertNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, "_scheduledExecutorService"));
+		}
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2732,6 +2732,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_PROGRESS_INTERVAL =
 		"upgrade.log.progress.interval";
 
+	public static final String UPGRADE_QUERY_MONITOR_ENABLED =
+		"upgrade.query.monitor.enabled";
+
 	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		"upgrade.query.monitor.lock.threshold";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2396,6 +2396,10 @@ public class PropsValues {
 	public static final long UPGRADE_LOG_PROGRESS_INTERVAL = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.UPGRADE_LOG_PROGRESS_INTERVAL));
 
+	public static final boolean UPGRADE_QUERY_MONITOR_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_ENABLED), true);
+
 	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),


### PR DESCRIPTION
## Summary

- Add `UpgradeQueryMonitor` as a static utility class (matching `UpgradeLogProgressTracker`'s pattern) that owns a daemon `ScheduledExecutorService` polling `DB.getLockedQueryInfos` every 60 seconds (hardcoded per spec).
- Each returned `QueryInfo` exceeding `upgrade.query.monitor.lock.threshold` is logged at WARN with the query text and duration in seconds.
- The monitor halts permanently on `SQLTimeoutException` or `SQLException` (unless the thread is interrupted) by rethrowing as `RuntimeException`, suppressing further executions via the `ScheduledExecutorService` contract.
- `DBUpgrader` calls `start`/`stop` statically alongside `UpgradeLogProgressTracker`.
- Adds `upgrade.query.monitor.enabled` (default `true`) and `upgrade.query.monitor.lock.threshold` (default `300000` ms) as configurable properties.

## Test Plan

- [ ] Deploy `portal-impl` and verify upgrade runs without errors.
- [ ] Confirm `UpgradeQueryMonitor` logs WARN for queries exceeding the threshold during a slow upgrade.
- [ ] Verify monitor stops cleanly after upgrade completes.