### PR TITLE
LPD-91049 Improve throughput of BaseJakartaUpgradeProcess and JakartaUpgradeProcessUtil

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseJakartaUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseJakartaUpgradeProcess.java
@@ -157,7 +157,7 @@ public abstract class BaseJakartaUpgradeProcess extends UpgradeProcess {
 		String columnName, String[] primaryKeyColumnNames, String tableName) {
 
 		StringBundler sb = new StringBundler(
-			(primaryKeyColumnNames.length * 2) + 7);
+			(primaryKeyColumnNames.length * 2) + 9);
 
 		sb.append("select ");
 
@@ -171,7 +171,9 @@ public abstract class BaseJakartaUpgradeProcess extends UpgradeProcess {
 		sb.append(tableName);
 		sb.append(" where ");
 		sb.append(columnName);
-		sb.append(" is not null");
+		sb.append(" like '%javax%' or ");
+		sb.append(columnName);
+		sb.append(" like '%JAVAX%'");
 
 		return sb.toString();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/JakartaUpgradeProcessUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/JakartaUpgradeProcessUtil.java
@@ -10,7 +10,9 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Luis Ortiz
@@ -72,13 +74,19 @@ public class JakartaUpgradeProcessUtil {
 
 		value = StringUtil.replace(value, sourcePackage, targetPackage);
 
+		String escapedSourcePackage = _escapedCache.computeIfAbsent(
+			sourcePackage, HtmlUtil::escapeJS);
+		String escapedTargetPackage = _escapedCache.computeIfAbsent(
+			targetPackage, HtmlUtil::escapeJS);
+
 		return StringUtil.replace(
-			value, HtmlUtil.escapeJS(sourcePackage),
-			HtmlUtil.escapeJS(targetPackage));
+			value, escapedSourcePackage, escapedTargetPackage);
 	}
 
 	private static final char[] _SEPARATORS = {'-', '/'};
 
+	private static final Map<String, String> _escapedCache =
+		new ConcurrentHashMap<>();
 	private static final Set<String> _preservedSubpackageNames = new HashSet<>(
 		Arrays.asList("annotation.processing", "transaction.xa"));
 	private static final Set<String> _subpackageNames = new HashSet<>(


### PR DESCRIPTION
## Summary

- Push the `javax` filter server-side in `BaseJakartaUpgradeProcess._getSelectSQL`: the WHERE clause now uses `LIKE '%javax%' OR LIKE '%JAVAX%'` instead of `IS NOT NULL`, so only rows that actually contain javax references are shipped from the database to the JVM.
- Cache `HtmlUtil.escapeJS` results in a static `ConcurrentHashMap` in `JakartaUpgradeProcessUtil._replace` via `computeIfAbsent`, so each of the ~250 distinct escaped strings is computed only once across the entire upgrade run.

## Test plan

- [ ] Run `JakartaUpgradeProcessUtilTest` unit tests: `cd portal-kernel && ant test-class -Dtest.class=JakartaUpgradeProcessUtilTest`
- [ ] Run `BaseJakartaUpgradeProcessTest` integration tests: `cd modules/apps/portal/portal-upgrade-test && ../../gradlew testIntegration --tests BaseJakartaUpgradeProcessTest`