### PR TITLE
LPD-92725 Cache group, article, and DDM template lookups during portlet preferences upgrade

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -72,17 +72,27 @@ public class UpgradePortletPreferences
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		Group group = _groups.computeIfAbsent(
-			groupId, key -> _groupLocalService.fetchGroup(key));
+		if (!_groups.containsKey(groupId)) {
+			_groups.put(groupId, _groupLocalService.fetchGroup(groupId));
+		}
+
+		Group group = _groups.get(groupId);
 
 		if (group == null) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		JournalArticle journalArticle = _journalArticles.computeIfAbsent(
-			groupId + StringPool.POUND + articleId,
-			key -> _journalArticleLocalService.fetchArticle(
-				groupId, articleId));
+		String journalArticleCacheKey =
+			groupId + StringPool.POUND + articleId;
+
+		if (!_journalArticles.containsKey(journalArticleCacheKey)) {
+			_journalArticles.put(
+				journalArticleCacheKey,
+				_journalArticleLocalService.fetchArticle(groupId, articleId));
+		}
+
+		JournalArticle journalArticle = _journalArticles.get(
+			journalArticleCacheKey);
 
 		if (journalArticle == null) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
@@ -117,17 +127,15 @@ public class UpgradePortletPreferences
 		String ddmTemplateCacheKey =
 			ddmTemplateGroupId + StringPool.POUND + ddmTemplateKey;
 
-		DDMTemplate ddmTemplate = _ddmTemplates.get(ddmTemplateCacheKey);
-
-		if (ddmTemplate == null) {
-			ddmTemplate = _ddmTemplateLocalService.fetchTemplate(
-				ddmTemplateGroupId, _ddmStructureClassNameId, ddmTemplateKey,
-				true);
-
-			if (ddmTemplate != null) {
-				_ddmTemplates.put(ddmTemplateCacheKey, ddmTemplate);
-			}
+		if (!_ddmTemplates.containsKey(ddmTemplateCacheKey)) {
+			_ddmTemplates.put(
+				ddmTemplateCacheKey,
+				_ddmTemplateLocalService.fetchTemplate(
+					ddmTemplateGroupId, _ddmStructureClassNameId,
+					ddmTemplateKey, true));
 		}
+
+		DDMTemplate ddmTemplate = _ddmTemplates.get(ddmTemplateCacheKey);
 
 		if (ddmTemplate == null) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -48,6 +48,18 @@ public class UpgradePortletPreferences
 	}
 
 	@Override
+	protected void doUpgrade() throws Exception {
+		try {
+			super.doUpgrade();
+		}
+		finally {
+			_ddmTemplates.clear();
+			_groups.clear();
+			_journalArticles.clear();
+		}
+	}
+
+	@Override
 	protected String[] getPortletIds() {
 		return new String[] {
 			JournalContentPortletKeys.JOURNAL_CONTENT + "_INSTANCE_%"

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -10,6 +10,7 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.journal.constants.JournalContentPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -19,6 +20,9 @@ import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -68,14 +72,17 @@ public class UpgradePortletPreferences
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		Group group = _groupLocalService.fetchGroup(groupId);
+		Group group = _groups.computeIfAbsent(
+			groupId, key -> _groupLocalService.fetchGroup(key));
 
 		if (group == null) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		JournalArticle journalArticle =
-			_journalArticleLocalService.fetchArticle(groupId, articleId);
+		JournalArticle journalArticle = _journalArticles.computeIfAbsent(
+			groupId + StringPool.POUND + articleId,
+			key -> _journalArticleLocalService.fetchArticle(
+				groupId, articleId));
 
 		if (journalArticle == null) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
@@ -107,8 +114,20 @@ public class UpgradePortletPreferences
 			}
 		}
 
-		DDMTemplate ddmTemplate = _ddmTemplateLocalService.fetchTemplate(
-			ddmTemplateGroupId, _ddmStructureClassNameId, ddmTemplateKey, true);
+		String ddmTemplateCacheKey =
+			ddmTemplateGroupId + StringPool.POUND + ddmTemplateKey;
+
+		DDMTemplate ddmTemplate = _ddmTemplates.get(ddmTemplateCacheKey);
+
+		if (ddmTemplate == null) {
+			ddmTemplate = _ddmTemplateLocalService.fetchTemplate(
+				ddmTemplateGroupId, _ddmStructureClassNameId, ddmTemplateKey,
+				true);
+
+			if (ddmTemplate != null) {
+				_ddmTemplates.put(ddmTemplateCacheKey, ddmTemplate);
+			}
+		}
 
 		if (ddmTemplate == null) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
@@ -124,8 +143,12 @@ public class UpgradePortletPreferences
 
 	private final long _ddmStructureClassNameId;
 	private final DDMTemplateLocalService _ddmTemplateLocalService;
+	private final Map<String, DDMTemplate> _ddmTemplates = new HashMap<>();
 	private final GroupLocalService _groupLocalService;
+	private final Map<Long, Group> _groups = new HashMap<>();
 	private final JournalArticleLocalService _journalArticleLocalService;
+	private final Map<String, JournalArticle> _journalArticles =
+		new HashMap<>();
 	private final LayoutLocalService _layoutLocalService;
 	private final Portal _portal;
 

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -21,10 +21,10 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
+import jakarta.portlet.PortletPreferences;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import jakarta.portlet.PortletPreferences;
 
 /**
  * @author Mikel Lorza
@@ -82,8 +82,7 @@ public class UpgradePortletPreferences
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		String journalArticleCacheKey =
-			groupId + StringPool.POUND + articleId;
+		String journalArticleCacheKey = groupId + StringPool.POUND + articleId;
 
 		if (!_journalArticles.containsKey(journalArticleCacheKey)) {
 			_journalArticles.put(

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -23,8 +23,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.portlet.PortletPreferences;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Mikel Lorza
@@ -72,28 +72,43 @@ public class UpgradePortletPreferences
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		if (!_groups.containsKey(groupId)) {
-			_groups.put(groupId, _groupLocalService.fetchGroup(groupId));
-		}
+		GroupInfo groupInfo = _groups.computeIfAbsent(
+			groupId,
+			key -> {
+				Group group = _groupLocalService.fetchGroup(key);
 
-		Group group = _groups.get(groupId);
+				if (group == null) {
+					return GroupInfo._MISSING;
+				}
 
-		if (group == null) {
+				return new GroupInfo(
+					group.isCompany(), group.getExternalReferenceCode());
+			});
+
+		if (groupInfo == GroupInfo._MISSING) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
 		String journalArticleCacheKey = groupId + StringPool.POUND + articleId;
 
-		if (!_journalArticles.containsKey(journalArticleCacheKey)) {
-			_journalArticles.put(
+		JournalArticleInfo journalArticleInfo =
+			_journalArticles.computeIfAbsent(
 				journalArticleCacheKey,
-				_journalArticleLocalService.fetchArticle(groupId, articleId));
-		}
+				key -> {
+					JournalArticle journalArticle =
+						_journalArticleLocalService.fetchArticle(
+							groupId, articleId);
 
-		JournalArticle journalArticle = _journalArticles.get(
-			journalArticleCacheKey);
+					if (journalArticle == null) {
+						return JournalArticleInfo._MISSING;
+					}
 
-		if (journalArticle == null) {
+					return new JournalArticleInfo(
+						journalArticle.getExternalReferenceCode(),
+						journalArticle.getGroupId());
+				});
+
+		if (journalArticleInfo == JournalArticleInfo._MISSING) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
@@ -101,9 +116,10 @@ public class UpgradePortletPreferences
 		portletPreferences.reset("groupId");
 		portletPreferences.setValue(
 			"articleExternalReferenceCode",
-			journalArticle.getExternalReferenceCode());
+			journalArticleInfo._getExternalReferenceCode());
 		portletPreferences.setValue(
-			"groupExternalReferenceCode", group.getExternalReferenceCode());
+			"groupExternalReferenceCode",
+			groupInfo._getExternalReferenceCode());
 
 		String ddmTemplateKey = portletPreferences.getValue(
 			"ddmTemplateKey", null);
@@ -112,51 +128,130 @@ public class UpgradePortletPreferences
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
-		long ddmTemplateGroupId = _portal.getSiteGroupId(
-			journalArticle.getGroupId());
-
-		if (group.isCompany()) {
-			Layout layout = _layoutLocalService.fetchLayout(plid);
-
-			if (layout != null) {
-				ddmTemplateGroupId = layout.getGroupId();
-			}
-		}
+		long ddmTemplateGroupId = _getDDMTemplateGroupId(
+			groupInfo, journalArticleInfo, plid);
 
 		String ddmTemplateCacheKey =
 			ddmTemplateGroupId + StringPool.POUND + ddmTemplateKey;
 
-		if (!_ddmTemplates.containsKey(ddmTemplateCacheKey)) {
-			_ddmTemplates.put(
-				ddmTemplateCacheKey,
-				_ddmTemplateLocalService.fetchTemplate(
-					ddmTemplateGroupId, _ddmStructureClassNameId,
-					ddmTemplateKey, true));
-		}
+		DDMTemplateInfo ddmTemplateInfo = _ddmTemplates.computeIfAbsent(
+			ddmTemplateCacheKey,
+			key -> {
+				DDMTemplate ddmTemplate =
+					_ddmTemplateLocalService.fetchTemplate(
+						ddmTemplateGroupId, _ddmStructureClassNameId,
+						ddmTemplateKey, true);
 
-		DDMTemplate ddmTemplate = _ddmTemplates.get(ddmTemplateCacheKey);
+				if (ddmTemplate == null) {
+					return DDMTemplateInfo._MISSING;
+				}
 
-		if (ddmTemplate == null) {
+				return new DDMTemplateInfo(
+					ddmTemplate.getExternalReferenceCode());
+			});
+
+		if (ddmTemplateInfo == DDMTemplateInfo._MISSING) {
 			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 		}
 
 		portletPreferences.reset("ddmTemplateKey");
 		portletPreferences.setValue(
 			"ddmTemplateExternalReferenceCode",
-			ddmTemplate.getExternalReferenceCode());
+			ddmTemplateInfo._getExternalReferenceCode());
 
 		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 	}
 
+	private long _getDDMTemplateGroupId(
+			GroupInfo groupInfo, JournalArticleInfo journalArticleInfo,
+			long plid)
+		throws Exception {
+
+		if (!groupInfo._isCompany()) {
+			return _portal.getSiteGroupId(journalArticleInfo._getGroupId());
+		}
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout != null) {
+			return layout.getGroupId();
+		}
+
+		return _portal.getSiteGroupId(journalArticleInfo._getGroupId());
+	}
+
 	private final long _ddmStructureClassNameId;
 	private final DDMTemplateLocalService _ddmTemplateLocalService;
-	private final Map<String, DDMTemplate> _ddmTemplates = new HashMap<>();
+	private final Map<String, DDMTemplateInfo> _ddmTemplates =
+		new ConcurrentHashMap<>();
 	private final GroupLocalService _groupLocalService;
-	private final Map<Long, Group> _groups = new HashMap<>();
+	private final Map<Long, GroupInfo> _groups = new ConcurrentHashMap<>();
 	private final JournalArticleLocalService _journalArticleLocalService;
-	private final Map<String, JournalArticle> _journalArticles =
-		new HashMap<>();
+	private final Map<String, JournalArticleInfo> _journalArticles =
+		new ConcurrentHashMap<>();
 	private final LayoutLocalService _layoutLocalService;
 	private final Portal _portal;
+
+	private static class DDMTemplateInfo {
+
+		private DDMTemplateInfo(String externalReferenceCode) {
+			_externalReferenceCode = externalReferenceCode;
+		}
+
+		private String _getExternalReferenceCode() {
+			return _externalReferenceCode;
+		}
+
+		private static final DDMTemplateInfo _MISSING = new DDMTemplateInfo(
+			null);
+
+		private final String _externalReferenceCode;
+
+	}
+
+	private static class GroupInfo {
+
+		private GroupInfo(boolean company, String externalReferenceCode) {
+			_company = company;
+			_externalReferenceCode = externalReferenceCode;
+		}
+
+		private String _getExternalReferenceCode() {
+			return _externalReferenceCode;
+		}
+
+		private boolean _isCompany() {
+			return _company;
+		}
+
+		private static final GroupInfo _MISSING = new GroupInfo(false, null);
+
+		private final boolean _company;
+		private final String _externalReferenceCode;
+
+	}
+
+	private static class JournalArticleInfo {
+
+		private JournalArticleInfo(String externalReferenceCode, long groupId) {
+			_externalReferenceCode = externalReferenceCode;
+			_groupId = groupId;
+		}
+
+		private String _getExternalReferenceCode() {
+			return _externalReferenceCode;
+		}
+
+		private long _getGroupId() {
+			return _groupId;
+		}
+
+		private static final JournalArticleInfo _MISSING =
+			new JournalArticleInfo(null, 0);
+
+		private final String _externalReferenceCode;
+		private final long _groupId;
+
+	}
 
 }


### PR DESCRIPTION
## Summary

Cache `Group`, `JournalArticle`, and `DDMTemplate` lookups inside the portlet preferences upgrade step to avoid redundant database queries when processing multiple preferences rows that reference the same entities.

## Changes

- Added local `HashMap` caches for group, article, and DDM template lookups in `UpgradePortletPreferences`.
- Populate each cache on first miss; return the cached value on subsequent lookups within the same upgrade run.

## Test plan

- Run the portlet preferences upgrade step against a portal instance with many Journal portlets.
- Verify the upgrade completes without errors and the expected DDM template IDs are stored.