### PR TITLE
LPD-91685 Add upgrade log assertion to portal smoke upgrade test batch

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3748,7 +3748,10 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
 
 									<if>
-										<equals arg1="${playwright.project.name}" arg2="smoke" />
+										<or>
+											<equals arg1="${playwright.project.name}" arg2="smoke.main" />
+											<contains string="${playwright.project.name}" substring="upgrade" />
+										</or>
 										<then>
 											<ant dir="portal-kernel" inheritAll="false" target="test-class">
 												<property name="test.class" value="PortalLogAssertorTest" />

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+function assert_clean_upgrade_log {
+	local upgrade_log="${LIFERAY_HOME}/tools/portal-tools-db-upgrade-client/logs/upgrade.log"
+
+	if [[ ! -f "${upgrade_log}" ]]
+	then
+		echo "Unable to find upgrade log at ${upgrade_log}."
+
+		return
+	fi
+
+	if grep -q -E "^[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} (ERROR|FATAL)" "${upgrade_log}"
+	then
+		echo "Unable to validate upgrade log due to ERROR or FATAL entries:"
+
+		grep -E "^[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} (ERROR|FATAL)" "${upgrade_log}"
+
+		exit 1
+	fi
+}
+
 function cluster_set_up {
 	default_set_up
 

--- a/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
@@ -20,6 +22,8 @@ function main {
 		rebuild-legacy-database
 
 	ant -f build-test.xml upgrade-legacy-database
+
+	assert_clean_upgrade_log
 
 	default_set_up
 }


### PR DESCRIPTION
Introduces `testScanUpgradeLog` in `PortalLogAssertorTest` to scan the upgrade client log for ERROR, FATAL, and WARN entries. Adds a `portal.log.assertor.enabled` system property so the assertor can run outside of Jenkins CI, and wires the new `liferay.upgrade.log.file` and `portal.log.assertor.enabled` JVM args through `build-common.xml`. Adds a new `playwright-js-portal-smoke-upgrade-tomcat101-postgresql163` Ant target and a `test.set.up.log.assert` attribute that triggers the assertor after the upgrade Playwright suite runs.