### PR TITLE
LPD-94069 Remove unpopulated-column guard from DuplicateUniqueFinderRowsCleaner

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DuplicateUniqueFinderRowsCleaner.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DuplicateUniqueFinderRowsCleaner.java
@@ -16,10 +16,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Types;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,10 +40,6 @@ public class DuplicateUniqueFinderRowsCleaner {
 	}
 
 	public boolean deleteDuplicates() throws Exception {
-		if (_hasUnpopulatedColumn()) {
-			return false;
-		}
-
 		boolean duplicatesDeleted = false;
 
 		List<String[]> duplicateColumnValuesList =
@@ -226,92 +220,6 @@ public class DuplicateUniqueFinderRowsCleaner {
 		}
 
 		return duplicateRows;
-	}
-
-	private boolean _hasUnpopulatedColumn() throws Exception {
-		Map<String, Integer> columnDataTypes = new HashMap<>();
-
-		DatabaseMetaData databaseMetaData = _connection.getMetaData();
-
-		DBInspector dbInspector = new DBInspector(_connection);
-
-		try (ResultSet resultSet = databaseMetaData.getColumns(
-				dbInspector.getCatalog(), dbInspector.getSchema(),
-				dbInspector.normalizeName(_tableName, databaseMetaData),
-				null)) {
-
-			while (resultSet.next()) {
-				columnDataTypes.put(
-					StringUtil.toLowerCase(resultSet.getString("COLUMN_NAME")),
-					resultSet.getInt("DATA_TYPE"));
-			}
-		}
-
-		StringBundler sb = new StringBundler();
-
-		sb.append("select count(*) as count");
-
-		for (String columnName : _columnNames) {
-			Integer dataType = columnDataTypes.get(
-				StringUtil.toLowerCase(columnName));
-
-			if ((dataType != null) && _isStringType(dataType)) {
-				sb.append(", count(nullif(");
-				sb.append(columnName);
-				sb.append(", '')) as count_");
-			}
-			else {
-				sb.append(", count(");
-				sb.append(columnName);
-				sb.append(") as count_");
-			}
-
-			sb.append(columnName);
-		}
-
-		sb.append(" from ");
-		sb.append(_tableName);
-
-		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				sb.toString());
-
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (!resultSet.next()) {
-				return false;
-			}
-
-			long totalCount = resultSet.getLong("count");
-
-			if (totalCount == 0) {
-				return false;
-			}
-
-			for (String columnName : _columnNames) {
-				if (resultSet.getLong("count_" + columnName) == 0) {
-					_log.error(
-						StringBundler.concat(
-							"Unable to delete duplicate records in table ",
-							_tableName, " because all values in column ",
-							columnName, " are null or empty"));
-
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	private boolean _isStringType(int dataType) {
-		if ((dataType == Types.CHAR) || (dataType == Types.LONGNVARCHAR) ||
-			(dataType == Types.LONGVARCHAR) || (dataType == Types.NCHAR) ||
-			(dataType == Types.NVARCHAR) || (dataType == Types.VARCHAR)) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Removes the `_hasUnpopulatedColumn` pre-check from `DuplicateUniqueFinderRowsCleaner.deleteDuplicates()`.

The guard queried column metadata and per-column row counts before attempting deletion, and returned `false` (skipping cleanup) whenever any unique-key column was entirely null or empty. This blocked duplicate cleanup in valid cases. Removing the guard lets the cleaner proceed in all cases.

Also drops the now-unused `_isStringType` helper and the `java.util.HashMap` and `java.sql.Types` imports.