### PR TITLE
LPD-91815 Add Ant-only test targets for UpgradeManagerMbean

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
@@ -4,11 +4,14 @@
 	<import file="util/build-test-upgrade-manager.xml" />
 
 	<macrodef name="assert-mbean-output">
-		<attribute name="expected.result" default="" />
-		<attribute name="expected.string" default="" />
-		<attribute name="expected.type" default="" />
+		<attribute default="" name="expected.result" />
+		<attribute default="" name="expected.string" />
+		<attribute default="" name="expected.type" />
 		<sequential>
-			<loadfile property="mbean.attributes.output" srcFile="${user.dir}/mbean-attributes-output.txt" />
+			<loadfile
+				property="mbean.attributes.output"
+				srcFile="${user.dir}/mbean-attributes-output.txt"
+			/>
 
 			<if>
 				<not>
@@ -114,9 +117,7 @@
 	<target name="test-check-mbean-warning-upgrade">
 		<property name="custom.startup.log.message" value="Upgrade report generated" />
 
-		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml"
-		     inheritAll="true"
-		     target="force-indexes-sql-failure" />
+		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml" inheritAll="true" target="force-indexes-sql-failure" />
 
 		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
 		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
@@ -141,9 +142,7 @@
 
 		<antcall target="rebuild-legacy-database" />
 
-		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml"
-		     inheritAll="true"
-		     target="force-indexes-sql-failure" />
+		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml" inheritAll="true" target="force-indexes-sql-failure" />
 
 		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
 		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />

--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0"?>
+
+<project basedir="." name="portal-upgrade-test-mbean" xmlns:antelope="antlib:ise.antelope.tasks">
+	<import file="util/build-test-upgrade-manager.xml" />
+
+	<macrodef name="assert-mbean-output">
+		<attribute name="expected.result" default="" />
+		<attribute name="expected.string" default="" />
+		<attribute name="expected.type" default="" />
+		<sequential>
+			<loadfile property="mbean.attributes.output" srcFile="${user.dir}/mbean-attributes-output.txt" />
+
+			<if>
+				<not>
+					<equals arg1="@{expected.string}" arg2="" />
+				</not>
+				<then>
+					<if>
+						<not>
+							<contains string="${mbean.attributes.output}" substring="@{expected.string}" />
+						</not>
+						<then>
+							<echo>${mbean.attributes.output}</echo>
+							<fail message="Expected string not present in the mBean file" />
+						</then>
+					</if>
+				</then>
+			</if>
+
+			<if>
+				<not>
+					<equals arg1="@{expected.type}" arg2="" />
+				</not>
+				<then>
+					<if>
+						<not>
+							<contains string="${mbean.attributes.output}" substring="Type: @{expected.type}" />
+						</not>
+						<then>
+							<echo>${mbean.attributes.output}</echo>
+							<fail message="Expected upgrade type not present in the mBean file" />
+						</then>
+					</if>
+				</then>
+			</if>
+
+			<if>
+				<not>
+					<equals arg1="@{expected.result}" arg2="" />
+				</not>
+				<then>
+					<if>
+						<not>
+							<contains string="${mbean.attributes.output}" substring="Result: @{expected.result}" />
+						</not>
+						<then>
+							<echo>${mbean.attributes.output}</echo>
+							<fail message="Expected upgrade result not present in the mBean file" />
+						</then>
+					</if>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<target name="test-check-mbean-during-upgrade-is-running">
+		<property name="custom.startup.log.message" value="Started web bundles" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="running" expected.type="pending" />
+	</target>
+
+	<target name="test-check-mbean-failed-upgrade">
+		<property name="custom.mysql.sql.statement" value="ALTER TABLE FragmentComposition DROP description;" />
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="failure" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-successful-upgrade">
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="success" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-warning-upgrade">
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+
+		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml"
+		     inheritAll="true"
+		     target="force-indexes-sql-failure" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="success" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-when-auto-upgrade-is-disabled">
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.string="Not Registered" />
+	</target>
+
+	<target name="test-check-mbean-when-upgrade-have-warn-and-error">
+		<property name="custom.mysql.sql.statement" value="ALTER TABLE FragmentComposition DROP description;" />
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml"
+		     inheritAll="true"
+		     target="force-indexes-sql-failure" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="failure" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-when-upgrade-its-not-executed">
+		<property name="custom.startup.log.message" value="upgrade finished with result" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="success" expected.type="major" />
+	</target>
+</project>

--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
@@ -8,6 +8,8 @@
 		<attribute default="" name="expected.string" />
 		<attribute default="" name="expected.type" />
 		<sequential>
+			<local name="mbean.attributes.output" />
+
 			<loadfile
 				property="mbean.attributes.output"
 				srcFile="${user.dir}/mbean-attributes-output.txt"
@@ -116,6 +118,11 @@
 
 	<target name="test-check-mbean-warning-upgrade">
 		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
 
 		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml" inheritAll="true" target="force-indexes-sql-failure" />
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91815

## What Is Being Fixed

The UpgradeManagerMbean functional tests are written as Poshi test cases, which require the Poshi runner and its CI property-injection framework to execute. The goal of this spike is to express the same seven MBean attribute assertions directly in Ant, eliminating the Poshi runner dependency.

## How It Is Being Fixed

Creates `UpgradeManagerMbean-tests.xml` with seven Ant target blocks (one per existing Poshi test), a shared `assert-mbean-output` macrodef, and an import of `util/build-test-upgrade-manager.xml`. Each target translates the Poshi properties (`data.archive.type`, `custom.startup.log.message`, `custom.mysql.sql.statement`, `custom.properties`) into explicit Ant property declarations and `antcall` steps, calling `rebuild-legacy-database`, `prepare-custom-properties`, and `start-app-server-check-mbean-attributes` in the same sequence the Poshi CI framework applied them. The `assert-mbean-output` macrodef covers both the Type+Result pattern (six tests) and the "Not Registered" string check (auto-upgrade-disabled test).

The `force-indexes-sql-failure` step (for the warning and warn+error tests) is invoked via `<ant antfile="...">` against `build-test-db-upgrade-client.xml` rather than importing it, keeping the import chain shallow.

## PR Check

**pr-check: SKIPPED** — new XML file only; no Java, no portal properties, no log4j configuration changed

<!-- pr-check {"reason": "new XML file only; no Java, no portal properties, no log4j configuration changed", "result": "skipped", "sha": "bce54402d51bc12104929cd60e10cef354bb73ad"} -->