### PR TITLE
LPD-94076 Add unit tests for PostUpgradeDataCleanupVerifyProcess

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
@@ -69,22 +69,12 @@ public class PostUpgradeDataCleanupVerifyProcess extends VerifyProcess {
 		}
 	}
 
-	private List<PostUpgradeDataCleanupProcess>
-		_getPostUpgradeDataCleanupProcesses() {
-
-		List<PostUpgradeDataCleanupProcess> postUpgradeDataCleanupProcesses =
-			ListUtil.fromArray(
-				new ClassNamePostUpgradeDataCleanupProcess(
-					_classNameLocalService, _companyLocalService, connection,
-					_objectDefinitionLocalService),
-				new ResourceActionPostUpgradeDataCleanupProcess(
-					connection, _resourceActionLocalService),
-				new ServiceComponentPostUpgradeDataCleanupProcess(
-					connection, _serviceComponentLocalService),
-				new StorePostUpgradeDataCleanupProcess(_store));
-
-		IndexInformation indexInformation = _indexInformationSnapshot.get();
-		IndexNameBuilder indexNameBuilder = _indexNameBuilderSnapshot.get();
+	protected List<PostUpgradeDataCleanupProcess>
+		getPostUpgradeDataCleanupProcesses(
+			IndexInformation indexInformation,
+			IndexNameBuilder indexNameBuilder,
+			List<PostUpgradeDataCleanupProcess>
+				postUpgradeDataCleanupProcesses) {
 
 		if ((indexInformation != null) && (indexNameBuilder != null)) {
 			postUpgradeDataCleanupProcesses.add(
@@ -98,6 +88,22 @@ public class PostUpgradeDataCleanupVerifyProcess extends VerifyProcess {
 		}
 
 		return postUpgradeDataCleanupProcesses;
+	}
+
+	private List<PostUpgradeDataCleanupProcess>
+		_getPostUpgradeDataCleanupProcesses() {
+
+		return getPostUpgradeDataCleanupProcesses(
+			_indexInformationSnapshot.get(), _indexNameBuilderSnapshot.get(),
+			ListUtil.fromArray(
+				new ClassNamePostUpgradeDataCleanupProcess(
+					_classNameLocalService, _companyLocalService, connection,
+					_objectDefinitionLocalService),
+				new ResourceActionPostUpgradeDataCleanupProcess(
+					connection, _resourceActionLocalService),
+				new ServiceComponentPostUpgradeDataCleanupProcess(
+					connection, _serviceComponentLocalService),
+				new StorePostUpgradeDataCleanupProcess(_store)));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
@@ -100,16 +100,15 @@ public class PostUpgradeDataCleanupVerifyProcess extends VerifyProcess {
 		return postUpgradeDataCleanupProcesses;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		PostUpgradeDataCleanupVerifyProcess.class);
+
 	private static final Snapshot<IndexInformation> _indexInformationSnapshot =
 		new Snapshot<>(
 			PostUpgradeDataCleanupVerifyProcess.class, IndexInformation.class);
-
 	private static final Snapshot<IndexNameBuilder> _indexNameBuilderSnapshot =
 		new Snapshot<>(
 			PostUpgradeDataCleanupVerifyProcess.class, IndexNameBuilder.class);
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		PostUpgradeDataCleanupVerifyProcess.class);
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -71,18 +72,41 @@ public class PostUpgradeDataCleanupVerifyProcess extends VerifyProcess {
 	private List<PostUpgradeDataCleanupProcess>
 		_getPostUpgradeDataCleanupProcesses() {
 
-		return ListUtil.fromArray(
-			new ClassNamePostUpgradeDataCleanupProcess(
-				_classNameLocalService, _companyLocalService, connection,
-				_objectDefinitionLocalService),
-			new ResourceActionPostUpgradeDataCleanupProcess(
-				connection, _resourceActionLocalService),
-			new SearchIndexPostUpgradeDataCleanupProcess(
-				_indexInformation, _indexNameBuilder),
-			new ServiceComponentPostUpgradeDataCleanupProcess(
-				connection, _serviceComponentLocalService),
-			new StorePostUpgradeDataCleanupProcess(_store));
+		List<PostUpgradeDataCleanupProcess> postUpgradeDataCleanupProcesses =
+			ListUtil.fromArray(
+				new ClassNamePostUpgradeDataCleanupProcess(
+					_classNameLocalService, _companyLocalService, connection,
+					_objectDefinitionLocalService),
+				new ResourceActionPostUpgradeDataCleanupProcess(
+					connection, _resourceActionLocalService),
+				new ServiceComponentPostUpgradeDataCleanupProcess(
+					connection, _serviceComponentLocalService),
+				new StorePostUpgradeDataCleanupProcess(_store));
+
+		IndexInformation indexInformation = _indexInformationSnapshot.get();
+		IndexNameBuilder indexNameBuilder = _indexNameBuilderSnapshot.get();
+
+		if ((indexInformation != null) && (indexNameBuilder != null)) {
+			postUpgradeDataCleanupProcesses.add(
+				new SearchIndexPostUpgradeDataCleanupProcess(
+					indexInformation, indexNameBuilder));
+		}
+		else if (_log.isWarnEnabled()) {
+			_log.warn(
+				"Unable to clean up orphaned search indexes because the " +
+					"search engine is unavailable");
+		}
+
+		return postUpgradeDataCleanupProcesses;
 	}
+
+	private static final Snapshot<IndexInformation> _indexInformationSnapshot =
+		new Snapshot<>(
+			PostUpgradeDataCleanupVerifyProcess.class, IndexInformation.class);
+
+	private static final Snapshot<IndexNameBuilder> _indexNameBuilderSnapshot =
+		new Snapshot<>(
+			PostUpgradeDataCleanupVerifyProcess.class, IndexNameBuilder.class);
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PostUpgradeDataCleanupVerifyProcess.class);
@@ -92,12 +116,6 @@ public class PostUpgradeDataCleanupVerifyProcess extends VerifyProcess {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
-
-	@Reference
-	private IndexInformation _indexInformation;
-
-	@Reference
-	private IndexNameBuilder _indexNameBuilder;
 
 	@Reference(target = ModuleServiceLifecycle.PORTLETS_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/test/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/test/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcessTest.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.data.cleanup.internal.verify;
+
+import com.liferay.portal.search.index.IndexInformation;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class PostUpgradeDataCleanupVerifyProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetPostUpgradeDataCleanupProcessesWhenSearchIsAvailable() {
+		PostUpgradeDataCleanupVerifyProcess
+			postUpgradeDataCleanupVerifyProcess =
+				new PostUpgradeDataCleanupVerifyProcess();
+
+		IndexInformation indexInformation = Mockito.mock(
+			IndexInformation.class);
+
+		IndexNameBuilder indexNameBuilder = Mockito.mock(
+			IndexNameBuilder.class);
+
+		Mockito.when(
+			indexNameBuilder.getIndexNamePrefix()
+		).thenReturn(
+			""
+		);
+
+		List<PostUpgradeDataCleanupProcess> baseProcesses = new ArrayList<>();
+
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				PostUpgradeDataCleanupVerifyProcess.class.getName(),
+				LoggerTestUtil.WARN)) {
+
+			List<PostUpgradeDataCleanupProcess>
+				postUpgradeDataCleanupProcesses =
+					postUpgradeDataCleanupVerifyProcess.
+						getPostUpgradeDataCleanupProcesses(
+							indexInformation, indexNameBuilder, baseProcesses);
+
+			Assert.assertEquals(
+				postUpgradeDataCleanupProcesses.toString(), 5,
+				postUpgradeDataCleanupProcesses.size());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
+		}
+	}
+
+	@Test
+	public void testGetPostUpgradeDataCleanupProcessesWhenSearchIsUnavailable() {
+		PostUpgradeDataCleanupVerifyProcess
+			postUpgradeDataCleanupVerifyProcess =
+				new PostUpgradeDataCleanupVerifyProcess();
+
+		List<PostUpgradeDataCleanupProcess> baseProcesses = new ArrayList<>();
+
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+		baseProcesses.add(Mockito.mock(PostUpgradeDataCleanupProcess.class));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				PostUpgradeDataCleanupVerifyProcess.class.getName(),
+				LoggerTestUtil.WARN)) {
+
+			List<PostUpgradeDataCleanupProcess>
+				postUpgradeDataCleanupProcesses =
+					postUpgradeDataCleanupVerifyProcess.
+						getPostUpgradeDataCleanupProcesses(
+							null, null, baseProcesses);
+
+			Assert.assertEquals(
+				postUpgradeDataCleanupProcesses.toString(), 4,
+				postUpgradeDataCleanupProcesses.size());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to clean up orphaned search indexes because the " +
+					"search engine is unavailable",
+				logEntry.getMessage());
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds `PostUpgradeDataCleanupVerifyProcessTest` with unit tests covering `getPostUpgradeDataCleanupProcesses` for scenarios when search services (IndexInformation, IndexNameBuilder) are available and when they are unavailable
- Fixes `getPostUpgradeDataCleanupProcesses` to correctly handle partial availability (one service available but not the other) and logs a warning when the search engine is unavailable

## Test plan

- [ ] Run `PostUpgradeDataCleanupVerifyProcessTest` unit tests pass
- [ ] Verify warning is logged when IndexInformation or IndexNameBuilder is null