### PR TITLE
LPS-193587 Test that setCompanyIdWithSafeCloseable flushes Hibernate session

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
@@ -24,6 +25,10 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.test.rule.Inject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -66,20 +71,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 				return null;
 			});
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					_company.getCompanyId())) {
-
-			Role role = _roleLocalService.fetchRole(
-				_company.getCompanyId(), name);
-
-			Assert.assertNotNull(role);
-		}
-
-		Role defaultRole = _roleLocalService.fetchRole(
-			TestPropsValues.getCompanyId(), name);
-
-		Assert.assertNull(defaultRole);
+		Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
+		Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
 	}
 
 	@Test
@@ -106,28 +99,12 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 				return null;
 			});
 
-		Role role = null;
-
 		try {
-			role = _roleLocalService.fetchRole(
-				TestPropsValues.getCompanyId(), name);
-
-			Assert.assertNotNull(role);
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						_company.getCompanyId())) {
-
-				Role otherRole = _roleLocalService.fetchRole(
-					_company.getCompanyId(), name);
-
-				Assert.assertNull(otherRole);
-			}
+			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
 		}
 		finally {
-			if (role != null) {
-				_roleLocalService.deleteRole(role.getRoleId());
-			}
+			_deleteRole(TestPropsValues.getCompanyId(), name);
 		}
 	}
 
@@ -143,6 +120,34 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		role.setType(RoleConstants.TYPE_REGULAR);
 
 		_rolePersistence.update(role);
+	}
+
+	private void _deleteRole(long companyId, String name) throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
+			Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"delete from Role_ where name = ?")) {
+
+			preparedStatement.setString(1, name);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private boolean _hasRole(long companyId, String name) throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
+			Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select roleId from Role_ where name = ?")) {
+
+			preparedStatement.setString(1, name);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
 	}
 
 	private static final TransactionConfig _transactionConfig;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -127,10 +127,15 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 			Assert.assertNotNull(role);
 
-			Role otherRole = _roleLocalService.fetchRole(
-				_company.getCompanyId(), name);
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						_company.getCompanyId())) {
 
-			Assert.assertNull(otherRole);
+				Role otherRole = _roleLocalService.fetchRole(
+					_company.getCompanyId(), name);
+
+				Assert.assertNull(otherRole);
+			}
 		}
 		finally {
 			if (role != null) {

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -6,20 +6,20 @@
 package com.liferay.portal.db.partition.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -40,13 +40,6 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_company = CompanyTestUtil.addCompany();
-
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					_company.getCompanyId())) {
-
-			_adminUser = UserTestUtil.getAdminUser(_company.getCompanyId());
-		}
 	}
 
 	@AfterClass
@@ -67,10 +60,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 							_company.getCompanyId())) {
 
-					_roleLocalService.addRole(
-						null, _adminUser.getUserId(), null, 0, name, null,
-						null, RoleConstants.TYPE_REGULAR, null,
-						new ServiceContext());
+					_addRole(_company.getCompanyId(), name);
 				}
 
 				return null;
@@ -101,10 +91,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		TransactionInvokerUtil.invoke(
 			_transactionConfig,
 			() -> {
-				_roleLocalService.addRole(
-					null, TestPropsValues.getUserId(), null, 0, name, null,
-					null, RoleConstants.TYPE_REGULAR, null,
-					new ServiceContext());
+				_addRole(TestPropsValues.getCompanyId(), name);
 
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -144,6 +131,20 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
+	private void _addRole(long companyId, String name) {
+		long roleId = _counterLocalService.increment();
+
+		Role role = _rolePersistence.create(roleId);
+
+		role.setCompanyId(companyId);
+		role.setClassNameId(_classNameLocalService.getClassNameId(Role.class));
+		role.setClassPK(roleId);
+		role.setName(name);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		_rolePersistence.update(role);
+	}
+
 	private static final TransactionConfig _transactionConfig;
 
 	static {
@@ -155,10 +156,18 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		_transactionConfig = builder.build();
 	}
 
-	private static User _adminUser;
 	private static Company _company;
 
 	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private RolePersistence _rolePersistence;
 
 }

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -71,8 +71,13 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 				return null;
 			});
 
-		Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
-		Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
+		try {
+			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
+		}
+		finally {
+			_deleteRole(TestPropsValues.getCompanyId(), name);
+		}
 	}
 
 	@Test
@@ -124,7 +129,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 	private void _deleteRole(long companyId, String name) throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+					companyId);
 			Connection connection = DataAccess.getConnection();
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"delete from Role_ where name = ?")) {
@@ -137,7 +143,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 	private boolean _hasRole(long companyId, String name) throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+					companyId);
 			Connection connection = DataAccess.getConnection();
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"select roleId from Role_ where name = ?")) {

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -10,7 +10,6 @@ import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
@@ -95,10 +94,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 							_company.getCompanyId())) {
 
-					DynamicQuery dynamicQuery =
-						_roleLocalService.dynamicQuery();
-
-					_roleLocalService.dynamicQuery(dynamicQuery);
+					_roleLocalService.dynamicQuery(
+						_roleLocalService.dynamicQuery());
 				}
 
 				return null;
@@ -124,14 +121,15 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		role.setName(name);
 		role.setType(RoleConstants.TYPE_REGULAR);
 
-		_rolePersistence.update(role);
+		_roleLocalService.updateRole(role);
 	}
 
 	private void _deleteRole(long companyId, String name) throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
-					companyId);
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(companyId);
+
 			Connection connection = DataAccess.getConnection();
+
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"delete from Role_ where name = ?")) {
 
@@ -143,9 +141,10 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 	private boolean _hasRole(long companyId, String name) throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
-					companyId);
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(companyId);
+
 			Connection connection = DataAccess.getConnection();
+
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"select roleId from Role_ where name = ?")) {
 
@@ -157,11 +156,10 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
+	private static Company _company;
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
-
-	private static Company _company;
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -157,16 +157,9 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
-	private static final TransactionConfig _transactionConfig;
-
-	static {
-		TransactionConfig.Builder builder = new TransactionConfig.Builder();
-
-		builder.setPropagation(Propagation.REQUIRED);
-		builder.setRollbackForClasses(Exception.class);
-
-		_transactionConfig = builder.build();
-	}
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
 
 	private static Company _company;
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.test.rule.Inject;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
+
+			_adminUser = UserTestUtil.getAdminUser(_company.getCompanyId());
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		companyLocalService.deleteCompany(_company.getCompanyId());
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnClose()
+		throws Throwable {
+
+		String name = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_roleLocalService.addRole(
+						null, _adminUser.getUserId(), null, 0, name, null,
+						null, RoleConstants.TYPE_REGULAR, null,
+						new ServiceContext());
+				}
+
+				return null;
+			});
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
+
+			Role role = _roleLocalService.fetchRole(
+				_company.getCompanyId(), name);
+
+			Assert.assertNotNull(role);
+		}
+
+		Role defaultRole = _roleLocalService.fetchRole(
+			TestPropsValues.getCompanyId(), name);
+
+		Assert.assertNull(defaultRole);
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry()
+		throws Throwable {
+
+		String name = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				_roleLocalService.addRole(
+					null, TestPropsValues.getUserId(), null, 0, name, null,
+					null, RoleConstants.TYPE_REGULAR, null,
+					new ServiceContext());
+
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					DynamicQuery dynamicQuery =
+						_roleLocalService.dynamicQuery();
+
+					_roleLocalService.dynamicQuery(dynamicQuery);
+				}
+
+				return null;
+			});
+
+		Role role = null;
+
+		try {
+			role = _roleLocalService.fetchRole(
+				TestPropsValues.getCompanyId(), name);
+
+			Assert.assertNotNull(role);
+
+			Role otherRole = _roleLocalService.fetchRole(
+				_company.getCompanyId(), name);
+
+			Assert.assertNull(otherRole);
+		}
+		finally {
+			if (role != null) {
+				_roleLocalService.deleteRole(role.getRoleId());
+			}
+		}
+	}
+
+	private static final TransactionConfig _transactionConfig;
+
+	static {
+		TransactionConfig.Builder builder = new TransactionConfig.Builder();
+
+		builder.setPropagation(Propagation.REQUIRED);
+		builder.setRollbackForClasses(Exception.class);
+
+		_transactionConfig = builder.build();
+	}
+
+	private static User _adminUser;
+	private static Company _company;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}


### PR DESCRIPTION
Add `TransactionFlushDBPartitionTest` to verify that `CompanyThreadLocal.setCompanyIdWithSafeCloseable` flushes the Hibernate session at the correct points: on entry (flush pending changes before switching partitions) and on close (flush changes made in the partition before returning).