### PR TITLE
LPD-96132 Cap upgrade worker threads to JDBC connection budget

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.BaseDBProcess;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -103,6 +105,9 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		_originalDataCleanupPreupgradeProcessesMap =
 			ReflectionTestUtil.getFieldValue(
 				this, "_dataCleanupPreupgradeProcessesMap");
+
+		ReflectionTestUtil.setFieldValue(
+			BaseDBProcess.class, "_fixedThreadPoolSize", new AtomicInteger(0));
 	}
 
 	@After
@@ -247,6 +252,37 @@ public class DataCleanupPreupgradeProcessSuiteTest
 
 		Assert.assertTrue(_cleanupMessages.contains(_SUCCESS_MESSAGE_1));
 		Assert.assertTrue(_cleanupMessages.contains(_SUCCESS_MESSAGE_2));
+	}
+
+	@Test
+	public void testDataCleanupPreupgradeProcessesSuiteWithPartitionEnabled()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"DATABASE_PARTITION_ENABLED", true)) {
+
+			ReflectionTestUtil.setFieldValue(
+				this, "_dataCleanupPreupgradeProcessesMap",
+				HashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						_createDataCleanupPreupgradeProcess(
+							() -> _cleanupMessages.add(_SUCCESS_MESSAGE_1)),
+						DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						_createDataCleanupPreupgradeProcess(
+							() -> _cleanupMessages.add(_SUCCESS_MESSAGE_2)),
+						DataCleanupPreupgradeProcess.dependsOn()
+					).build());
+
+			cleanUp();
+
+			Assert.assertTrue(
+				_cleanupMessages.contains(_SUCCESS_MESSAGE_1));
+			Assert.assertTrue(
+				_cleanupMessages.contains(_SUCCESS_MESSAGE_2));
+		}
 	}
 
 	private static void _updatePortalSchemaVersion(String schemaVersion)

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -704,26 +704,28 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		Runtime runtime = Runtime.getRuntime();
 
-		int expectedMaxConnectionsCount =
-			Math.min(companyIds.length - 1, runtime.availableProcessors()) *
-				runtime.availableProcessors();
+		int availableProcessors = runtime.availableProcessors();
 
-		if (expectedMaxConnectionsCount > (0.9 * maximumPoolSize)) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"The database is close to reaching ", maximumPoolSize,
-						" connections. Consider increasing the property ",
-						"\"jdbc.default.maximumPoolSize\" to improve ",
-						"performance. Upgrade processes will continue in ",
-						"single threaded mode."));
-			}
+		int companyCount = Math.max(1, companyIds.length);
 
-			_fixedThreadPoolSize.set(1);
+		int connectionBudget = Math.max(
+			1, (int)(0.9 * maximumPoolSize / companyCount));
+
+		int fixedThreadPoolSize = Math.min(availableProcessors, connectionBudget);
+
+		if ((fixedThreadPoolSize < availableProcessors) &&
+			_log.isWarnEnabled()) {
+
+			_log.warn(
+				StringBundler.concat(
+					"Limiting upgrade worker threads to ", fixedThreadPoolSize,
+					" to avoid exhausting the database connection pool of ",
+					"size ", maximumPoolSize,
+					". Consider increasing \"jdbc.default.maximumPoolSize\" ",
+					"to improve upgrade performance."));
 		}
-		else {
-			_fixedThreadPoolSize.set(runtime.availableProcessors());
-		}
+
+		_fixedThreadPoolSize.set(fixedThreadPoolSize);
 
 		return _fixedThreadPoolSize.get();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -711,7 +711,8 @@ public abstract class BaseDBProcess implements DBProcess {
 		int connectionBudget = Math.max(
 			1, (int)(0.9 * maximumPoolSize / companyCount));
 
-		int fixedThreadPoolSize = Math.min(availableProcessors, connectionBudget);
+		int fixedThreadPoolSize = Math.min(
+			availableProcessors, connectionBudget);
 
 		if ((fixedThreadPoolSize < availableProcessors) &&
 			_log.isWarnEnabled()) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
@@ -24,21 +24,30 @@ public class BaseDBProcessTest {
 
 	@Test
 	public void testGetFixedThreadPoolSize() throws Exception {
-		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 1);
-
 		Runtime runtime = Runtime.getRuntime();
 
-		_testGetFixedThreadPoolSize(
-			DBType.MYSQL, runtime.availableProcessors(), 1000);
+		int availableProcessors = runtime.availableProcessors();
 
-		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1000);
+		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1, 1000);
+
+		// Ample pool, single company: all processors are used
+
+		_testGetFixedThreadPoolSize(DBType.MYSQL, availableProcessors, 1, 1000);
+
+		// Small pool, single company (LPD-96132): cap to connection budget
+
+		int smallPoolSize = 10;
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(availableProcessors, (int)(0.9 * smallPoolSize)), 1,
+			smallPoolSize);
 	}
 
 	private void _testGetFixedThreadPoolSize(
-			DBType dbType, int expectedFixedThreadPoolSize, int maximumPoolSize)
+			DBType dbType, int expectedFixedThreadPoolSize, int companyCount,
+			int maximumPoolSize)
 		throws Exception {
-
-		Runtime runtime = Runtime.getRuntime();
 
 		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
 				Mockito.mockStatic(DBManagerUtil.class);
@@ -64,7 +73,7 @@ public class BaseDBProcessTest {
 			portalInstancePoolMockedStatic.when(
 				PortalInstancePool::getCompanyIds
 			).thenReturn(
-				new long[runtime.availableProcessors() + 2]
+				new long[companyCount]
 			);
 
 			propsUtilMockedStatic.when(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
@@ -42,6 +42,20 @@ public class BaseDBProcessTest {
 			DBType.MYSQL,
 			Math.min(availableProcessors, (int)(0.9 * smallPoolSize)), 1,
 			smallPoolSize);
+
+		// Small pool, multiple companies: connection budget is split per company
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(availableProcessors, (int)(0.9 * smallPoolSize / 5)), 5,
+			smallPoolSize);
+
+		// No companies: guard defaults to one company to avoid dividing by zero
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(availableProcessors, (int)(0.9 * smallPoolSize)), 0,
+			smallPoolSize);
 	}
 
 	private void _testGetFixedThreadPoolSize(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96132

## What Is Being Fixed

Running `db_upgrade_client.sh` on a high-core-count host against a database-partitioned environment fails during the preupgrade data cleanup phase. The JDBC connection pool is exhausted, producing 259+ "Unable to get the default company ID by SQL" errors and 44+ `DBInspector` NPEs, which cascade into a failed upgrade.

## How It Is Being Fixed

The previous formula in `BaseDBProcess._getFixedThreadPoolSize` estimated peak connection demand as `(companyIds.length - 1) * availableProcessors`. During `db_upgrade_client.sh` the `PortalInstancePool` cache is never enabled (only `MainServlet._initCompanies` enables it), so `getCompanyIds()` returns only the SYSTEM entry. This makes the multiplier zero and the guard condition always false, so the thread count defaults to `availableProcessors()` — 32 on a high-core machine. Each worker opens its own per-company connection plus a transient `getDefaultCompanyId()` SQL connection, exhausting the pool.

The fix replaces the binary cap with a graduated one: worker threads are bounded to `floor(0.9 * maximumPoolSize / companyCount)`, ensuring the worker count never exceeds what the connection pool can support regardless of CPU count. When the cap fires, a warning log tells operators the effective thread count and that increasing `jdbc.default.maximumPoolSize` restores full concurrency.

## PR Check

**pr-check: PASS** — tested on `96c852c12fafdaf630e742a7c235e5415bcc8568`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7e937550aead732f0675a161082fae48795b9cf0"} -->
