### PR TITLE
LPD-92865 Grant SELECT_CATALOG_ROLE to lportal in Oracle legacy-import CI path

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16027,7 +16027,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot;&#10;grant select_catalog_role to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot;&#10;grant select_catalog_role to ${database.username};&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -15810,9 +15810,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									sqlplus /nolog <<-'EOF'
 									whenever sqlerror exit failure
-									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
-									grant select on sys.v_$session to ${database.username};
-									grant select on sys.v_$sql to ${database.username};
+									connect ${oracle.admin.user}/"${oracle.admin.password}"
+									grant select_catalog_role to ${database.username};
 									exit
 									EOF
 								]]>
@@ -16028,7 +16027,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot;&#10;grant select_catalog_role to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92865

## What

Grant `SELECT_CATALOG_ROLE` to `lportal` in the Oracle legacy-import CI path (both Docker and non-Docker variants) after `impdp` restores the database.

## Why

The previous fix (LPD-90738) connected as `${oracle.admin.user}` (defaults to `SYSTEM`) with `as sysdba` and granted `SELECT` directly on `sys.v_$session` and `sys.v_$sql`. `SYSTEM` does not hold `SYSDBA` privilege, so the connection silently falls back or fails, the grants never execute, and `lportal` still lacks catalog view access at upgrade time. `UpgradeQueryMonitor` then logs a warning that fails the smoke test under `test.assert.warning.exceptions=true`.

`SELECT_CATALOG_ROLE` can be granted by `SYSTEM` (which holds the `DBA` role) without requiring `SYSDBA`. It gives `lportal` read access to all data dictionary views, including `v_$session` and `v_$sql`, satisfying `UpgradeQueryMonitor`'s requirements.

## Files

- `build-test.xml` — Docker import path and non-Docker import path