### PR TITLE
LPD-96471 Collect SELECT rows before concurrent UPDATE workers start

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -462,6 +462,8 @@ public abstract class BaseDBProcess implements DBProcess {
 			String exceptionMessage)
 		throws Exception {
 
+		List<Object[]> rows = new ArrayList<>();
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				sql)) {
 
@@ -471,18 +473,32 @@ public abstract class BaseDBProcess implements DBProcess {
 			unsafeConsumer.accept(preparedStatement);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				_processConcurrently(
-					updateSQL,
-					() -> {
-						if (resultSet.next()) {
-							return unsafeFunction.apply(resultSet);
-						}
-
-						return null;
-					},
-					null, unsafeBiConsumer, exceptionMessage);
+				while (resultSet.next()) {
+					rows.add(unsafeFunction.apply(resultSet));
+				}
 			}
 		}
+
+		if (rows.isEmpty()) {
+			return;
+		}
+
+		Object[][] values = rows.toArray(new Object[0][]);
+
+		AtomicInteger counter = new AtomicInteger();
+
+		_processConcurrently(
+			updateSQL,
+			() -> {
+				int index = counter.getAndIncrement();
+
+				if (index < values.length) {
+					return values[index];
+				}
+
+				return null;
+			},
+			null, unsafeBiConsumer, exceptionMessage);
 	}
 
 	protected void processConcurrently(
@@ -492,22 +508,38 @@ public abstract class BaseDBProcess implements DBProcess {
 			String exceptionMessage)
 		throws Exception {
 
+		List<Object[]> rows = new ArrayList<>();
+
 		try (Statement statement = connection.createStatement()) {
 			statement.setFetchSize(PropsValues.UPGRADE_CONCURRENT_FETCH_SIZE);
 
 			try (ResultSet resultSet = statement.executeQuery(sql)) {
-				_processConcurrently(
-					null,
-					() -> {
-						if (resultSet.next()) {
-							return unsafeFunction.apply(resultSet);
-						}
-
-						return null;
-					},
-					unsafeConsumer, null, exceptionMessage);
+				while (resultSet.next()) {
+					rows.add(unsafeFunction.apply(resultSet));
+				}
 			}
 		}
+
+		if (rows.isEmpty()) {
+			return;
+		}
+
+		Object[][] values = rows.toArray(new Object[0][]);
+
+		AtomicInteger counter = new AtomicInteger();
+
+		_processConcurrently(
+			null,
+			() -> {
+				int index = counter.getAndIncrement();
+
+				if (index < values.length) {
+					return values[index];
+				}
+
+				return null;
+			},
+			unsafeConsumer, null, exceptionMessage);
 	}
 
 	protected <T> void processConcurrently(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -483,8 +483,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			return;
 		}
 
-		Object[][] values = rows.toArray(new Object[0][]);
-
 		AtomicInteger counter = new AtomicInteger();
 
 		_processConcurrently(
@@ -492,8 +490,8 @@ public abstract class BaseDBProcess implements DBProcess {
 			() -> {
 				int index = counter.getAndIncrement();
 
-				if (index < values.length) {
-					return values[index];
+				if (index < rows.size()) {
+					return rows.get(index);
 				}
 
 				return null;
@@ -524,8 +522,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			return;
 		}
 
-		Object[][] values = rows.toArray(new Object[0][]);
-
 		AtomicInteger counter = new AtomicInteger();
 
 		_processConcurrently(
@@ -533,8 +529,8 @@ public abstract class BaseDBProcess implements DBProcess {
 			() -> {
 				int index = counter.getAndIncrement();
 
-				if (index < values.length) {
-					return values[index];
+				if (index < rows.size()) {
+					return rows.get(index);
 				}
 
 				return null;


### PR DESCRIPTION
## Summary

- In DB2 with `autoCommit=true` and `progressiveStreaming=2`, forward-only cursors are closed immediately after `executeQuery()` commits.
- Worker threads calling `resultSet.next()` from a different thread then fail with `ERRORCODE=-4470` (result set is closed).
- Both `processConcurrently` overloads in `BaseDBProcess` now collect all rows from the SELECT cursor into a list on the main thread before starting concurrent UPDATE workers, so the cursor is fully closed before any worker runs.

## Test Plan

- [ ] Verify `processConcurrently` behaves correctly on DB2 with `autoCommit=true` and `progressiveStreaming=2`
- [ ] Verify no regression on other supported databases