### PR TITLE
LPD-80594 Navigate to site context when site is set even when toggle is present

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -83,16 +83,15 @@ definition {
 
 	@summary = "Default summary"
 	macro gotoPortlet(site = null, portlet = null, category = null) {
-		if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
+		if (isSet(site)) {
+			var siteNameURL = StringUtil.replace(${site}, " ", "-");
+
+			var siteNameURL = StringUtil.lowerCase(${siteNameURL});
+
+			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+		}
+		else if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});
-
-			if (isSet(site)) {
-				var siteNameURL = StringUtil.replace(${site}, " ", "-");
-
-				var siteNameURL = StringUtil.lowerCase(${siteNameURL});
-
-				Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
-			}
 		}
 
 		ProductMenuHelper.openProductMenu();


### PR DESCRIPTION
## Summary

- Fix `ProductMenu.gotoPortlet` to navigate to the site context when a site is set, even when the product menu toggle is present.
- Previously the site-URL navigation was nested inside the `IsElementNotPresent(TOGGLE)` block, so it was skipped when the toggle existed.
- Moved the site-context navigation outside the toggle check so it always runs when `site` is provided.

## Test plan

- [ ] Run a Poshi functional test that calls `ProductMenu.gotoPortlet` with a `site` parameter and verify it navigates to the correct site context regardless of the toggle visibility.