### PR TITLE
LPD-97431 Bound the slow query and stop logging its timeout as an error

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -727,24 +728,7 @@ public class DBTest {
 			}
 		}
 		finally {
-			if (futureTask != null) {
-				try {
-					futureTask.get(30, TimeUnit.SECONDS);
-				}
-				catch (TimeoutException timeoutException) {
-					futureTask.cancel(true);
-
-					if (_log.isDebugEnabled()) {
-						_log.debug(
-							"Unable to run locked query", timeoutException);
-					}
-				}
-				catch (Exception exception) {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Unable to run locked query", exception);
-					}
-				}
-			}
+			_awaitWorker(futureTask, "Unable to run locked query");
 		}
 	}
 
@@ -788,6 +772,10 @@ public class DBTest {
 			boolean foundLongRunningQuery = false;
 
 			while (System.currentTimeMillis() < endTime) {
+				if (futureTask.isDone()) {
+					futureTask.get();
+				}
+
 				for (DB.QueryInfo queryInfo :
 						db.getLongRunningQueryInfos(pollingConnection)) {
 
@@ -826,23 +814,7 @@ public class DBTest {
 			Assert.assertTrue(foundLongRunningQuery);
 		}
 		finally {
-			if (futureTask != null) {
-				try {
-					futureTask.get(30, TimeUnit.SECONDS);
-				}
-				catch (TimeoutException timeoutException) {
-					futureTask.cancel(true);
-
-					if (_log.isDebugEnabled()) {
-						_log.debug("Unable to run slow query", timeoutException);
-					}
-				}
-				catch (Exception exception) {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Unable to run slow query", exception);
-					}
-				}
-			}
+			_awaitWorker(futureTask, "Unable to run slow query");
 		}
 	}
 
@@ -940,24 +912,7 @@ public class DBTest {
 			}
 		}
 		finally {
-			if (futureTask != null) {
-				try {
-					futureTask.get(30, TimeUnit.SECONDS);
-				}
-				catch (TimeoutException timeoutException) {
-					futureTask.cancel(true);
-
-					if (_log.isDebugEnabled()) {
-						_log.debug(
-							"Unable to run locked query", timeoutException);
-					}
-				}
-				catch (Exception exception) {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Unable to run locked query", exception);
-					}
-				}
-			}
+			_awaitWorker(futureTask, "Unable to run locked query");
 		}
 	}
 
@@ -1282,6 +1237,28 @@ public class DBTest {
 	protected static DB db;
 	protected static DBInspector dbInspector;
 
+	private void _awaitWorker(FutureTask<Void> futureTask, String message)
+		throws Exception {
+
+		if (futureTask == null) {
+			return;
+		}
+
+		try {
+			futureTask.get(30, TimeUnit.SECONDS);
+		}
+		catch (ExecutionException executionException) {
+			if (_log.isInfoEnabled()) {
+				_log.info(message, executionException.getCause());
+			}
+		}
+		catch (TimeoutException timeoutException) {
+			futureTask.cancel(true);
+
+			throw timeoutException;
+		}
+	}
+
 	private void _createTestTable(String tableName) throws Exception {
 		db.runSQL(
 			StringBundler.concat(
@@ -1333,7 +1310,7 @@ public class DBTest {
 
 		if (dbType == DBType.DB2) {
 			return "with t(n) as (values 1 union all select n+1 from t where " +
-				"n < 50000000) select max(n) from t";
+				"n < 5000000) select max(n) from t";
 		}
 		else if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
 			return "select sleep(2)";

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -730,8 +731,18 @@ public class DBTest {
 				try {
 					futureTask.get(30, TimeUnit.SECONDS);
 				}
+				catch (TimeoutException timeoutException) {
+					futureTask.cancel(true);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to run locked query", timeoutException);
+					}
+				}
 				catch (Exception exception) {
-					_log.error(exception);
+					if (_log.isDebugEnabled()) {
+						_log.debug("Unable to run locked query", exception);
+					}
 				}
 			}
 		}
@@ -757,6 +768,8 @@ public class DBTest {
 
 						Statement statement =
 							backgroundConnection.createStatement()) {
+
+						statement.setQueryTimeout(10);
 
 						statement.execute(slowQuery);
 					}
@@ -817,8 +830,17 @@ public class DBTest {
 				try {
 					futureTask.get(30, TimeUnit.SECONDS);
 				}
+				catch (TimeoutException timeoutException) {
+					futureTask.cancel(true);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Unable to run slow query", timeoutException);
+					}
+				}
 				catch (Exception exception) {
-					_log.error(exception);
+					if (_log.isDebugEnabled()) {
+						_log.debug("Unable to run slow query", exception);
+					}
 				}
 			}
 		}
@@ -922,8 +944,18 @@ public class DBTest {
 				try {
 					futureTask.get(30, TimeUnit.SECONDS);
 				}
+				catch (TimeoutException timeoutException) {
+					futureTask.cancel(true);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to run locked query", timeoutException);
+					}
+				}
 				catch (Exception exception) {
-					_log.error(exception);
+					if (_log.isDebugEnabled()) {
+						_log.debug("Unable to run locked query", exception);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Draft — proposed fix for LPD-97431. Not verified in CI, not for team review yet.

**Root cause.** `DBTest#testGetLongRunningQueryInfos` scopes its `Statement` inside the worker lambda, so the cleanup block can only wait for the slow query, never stop it. On DB2 that query is an unbounded recursive CTE rather than the 2-second sleep other vendors use, so the 30s wait expires. The cleanup then calls `_log.error(exception)`, which binds to `Log.error(Throwable)` and logs `getMessage()` — null for a `TimeoutException`. That bare null line is what `PortalLogAssertorTest#testScanXMLLog` scans and fails on.

**Change.** All three remedies from the ticket's own Suggested Fix: `setQueryTimeout(10)` bounds the query, `futureTask.cancel(true)` interrupts the worker, and the timeout logs at debug. Debug rather than warn — the assertor fails on warn too.

All three identical cleanup blocks are changed. Only the middle one can fire today, but the others carry the same error-level logging of an expected timeout.

**Note for review.** This method has had two recent fixes — LPD-91359 (Luis Ortiz, 2026-07-01) and LPD-91523 (Mariano Alvaro, 2026-05-22). This builds on both rather than rediscovering the problem.

**Unverified.** Whether db2jcc honours `setQueryTimeout` on a recursive CTE. Does not block: the Suggested Fix offers the halves disjunctively and the log-level change alone satisfies the criteria.
