### PR TITLE
LPD-98371 Schedule web content with a date the publish modal accepts

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1547,7 +1547,7 @@ definition {
 
 	@summary = "Default summary"
 	macro increaseDisplayDate(minuteIncrease = null) {
-		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd HH:mm", "UTC");
+		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd hh:mm a", "UTC");
 
 		WebContent.scheduleWCArticleWithPermissions(displayDate = ${displayDate});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
@@ -1894,7 +1894,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00 AM");
 		}
 
 		task ("Go to Content Dashboard and click on the title") {
@@ -3694,7 +3694,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title Scheduled");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00 AM");
 		}
 
 		task ("Filter asset at Content Dashboard using status") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
@@ -1596,7 +1596,7 @@ definition {
 			webContentContent = "Web Content Content",
 			webContentTitle = "Web Content Title");
 
-		WebContent.scheduleWCArticleWithPermissions(displayDate = "01/01/2050");
+		WebContent.scheduleWCArticleWithPermissions(displayDate = "2050-01-01 01:00 AM");
 
 		Publications.publishPublication(
 			gotoPublicationsAdmin = "true",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -1113,7 +1113,7 @@ definition {
 				webContentContent = "Web Content Content",
 				webContentTitle = "Web Content Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01 AM");
 		}
 
 		task ("Add a page with a Web Content Display widget and display the Web Content article in the Web Content Display widget") {


### PR DESCRIPTION
Draft — proposed fix for LPD-98371. Not verified in CI, not for team review yet.

**Root cause.** The `label-item` span is missing because the article was never scheduled. The LPD-96224 series requires the display date as `yyyy-MM-dd hh:mm a`, exactly 19 characters. The shared macro and three testcases still supply 16- or 10-character values, so the gate rejects them silently and the article stays unscheduled.

**Change.** 5 lines across 4 files — the date format in `WebContent.macro:1550` plus four hardcoded literals.

**Should also close LPD-98372.** Both tests live in `DatabasePartitioning.testcase`, neither has a hardcoded date, and both route through `WebContent.increaseDisplayDate` — the macro fixed here. LPD-98371's test at `:188` calls it at `:211` and `:235`; LPD-98372's at `:778` calls it at `:809` and `:832`. Suggest leaving LPD-98372 open until its own test is green rather than closing on analysis.

**Related, unticketed.** `ContentDashboard#FilterByStatusScheduled` appears to fail the same way in the non-partitioned suite.
