### PR TITLE
LPD-91364 Land on Pages admin so the Product Menu renders

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -88,7 +88,7 @@ definition {
 
 			var siteNameURL = StringUtil.lowerCase(${siteNameURL});
 
-			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage?p_p_id=com_liferay_layout_admin_web_portlet_GroupPagesPortlet");
 		}
 		else if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});


### PR DESCRIPTION
Draft — proposed fix for LPD-91364. Not verified in CI, not for team review yet.

**Root cause.** `ProductMenu.gotoPortlet` navigated to `control_panel/manage` with no `p_p_id`. Without a portlet ID the current portlet resolves to the Applications Menu, and `isShowProductMenu()` returns false for an Applications Menu app — so the Product Menu and its toggle never render and the Site Builder category cannot be found. The locator is correct; the page has no Product Menu at all.

**Change.** One line: append `p_p_id=com_liferay_layout_admin_web_portlet_GroupPagesPortlet`, matching how `PagesAdmin.openPagesAdmin` already reaches site administration.

**Checked and ruled out.** The appended `p_p_id` does not make `_isApplicationsMenuApp` true — `PanelCategoryHelper.isApplicationsMenuApp` matches on the `applications_menu` portlet name. And `data-qa-id="appGroup"` is not dead markup; it is emitted at `application-list-taglib` `panel/page.jsp:47`.

**Why this branch matters.** This is the same defect as LPD-98370, and liferay-database-infra#3792 carried an identical one-line diff — but that PR is **closed and unmerged**, and master still has the unfixed line. This branch is currently the only carrier of the fix.
