### PR TITLE
LPD-93893 Say why the automatic database upgrade was skipped

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -155,10 +155,23 @@ public class DBUpgrader {
 			return _upgradeDatabaseAutoRun;
 		}
 
-		if (StartupHelperUtil.isDBNew() ||
-			(DBManagerUtil.getDBType() == DBType.HYPERSONIC)) {
+		boolean dbNew = StartupHelperUtil.isDBNew();
 
+		if (dbNew || (DBManagerUtil.getDBType() == DBType.HYPERSONIC)) {
 			_upgradeDatabaseAutoRun = false;
+
+			if (_log.isInfoEnabled()) {
+				if (dbNew) {
+					_log.info(
+						"Skipping the automatic database upgrade because the " +
+							"database is new");
+				}
+				else {
+					_log.info(
+						"Skipping the automatic database upgrade because " +
+							"Hypersonic does not support it");
+				}
+			}
 		}
 		else {
 			_upgradeDatabaseAutoRun = GetterUtil.getBoolean(


### PR DESCRIPTION
Draft — observability change for LPD-93893. **This is not a fix for the ticket's failure.** Not verified in CI, not for team review yet.

The mvccVersion failure remains unresolved; its trigger has not been identified. This change only makes the decision that causes it visible.

**What is silent today.** `DBUpgrader:158` forces the automatic upgrade off when `StartupHelperUtil.isDBNew()` is true, ignoring `upgrade.database.auto.run` entirely, and records nothing. An operator sees the property set to true, sees no upgrade run, and cannot connect the two. On a restored legacy archive the override is itself the symptom — a populated database being treated as new is the defect, not a configuration choice.

**Change.** State the decision at info, the level the log assertor tolerates. Warn would trip `PortalLogAssertorTest` on every Hypersonic run. `isDBNew()` is read once into a local so the message cannot disagree with the branch it explains.

**Why it is worth having.** Five source-derived hypotheses about this failure were refuted, in large part because the skip is invisible and every relevant catch on that path logs at debug while CI runs at info. This turns the next already-scheduled nightly into an informative one. No CI run is being requested.
